### PR TITLE
Print length bugfix

### DIFF
--- a/src/tree.jl
+++ b/src/tree.jl
@@ -426,7 +426,7 @@ function Base.show(io::IO, ::MIME"text/plain", tree::AVLTree{K,D}) where {K,D}
         push!(str_lst, indent_str * "$k => $v")
     end
     if length(str_lst) > 0
-        print(io, "AVLTree{$K,$D} with $(length(str_lst)) entries:\n")
+        print(io, "AVLTree{$K,$D} with $(length(tree)) entries:\n")
         print(io, join(str_lst, "\n"))
     else
         print(io, "AVLTree{$K,$D}()")


### PR DESCRIPTION
Fixed print length bug in which length displayed in show method was capped at 10.

For now, `print` and `show` will only display the first 10 items, where this number is hardcoded. Show will now display the correct tree size.